### PR TITLE
small fix to avoid compiler error when using O2 optimization. 

### DIFF
--- a/src/M2M_TLV.cpp
+++ b/src/M2M_TLV.cpp
@@ -475,8 +475,8 @@ bool M2M_TLV::readBoolean(M2M_TLV::ResourceSpecifier rs)
 
 double M2M_TLV::readDouble(M2M_TLV::ResourceSpecifier rs)
 {
-	uint64_t eightBytes;
-	size_t   length;
+	uint64_t eightBytes = 0;
+	size_t   length = 0;
 
 	if (!readUint(eightBytes, length, rs))
 		return NAN;


### PR DESCRIPTION
with compiler optimization O2 I got "may be used uninitialized"